### PR TITLE
Roll back to user count condition.

### DIFF
--- a/modules/iam-group/main.tf
+++ b/modules/iam-group/main.tf
@@ -31,7 +31,7 @@ resource "oci_identity_user_group_membership" "this" {
   # https://github.com/hashicorp/terraform/issues/12570
   # count    = "${length(var.user_ids)}"
   # use workaround here
-  count = "${var.group_create || length(lookup(local.group_ids[0], "id")) > 0 ? var.user_count : 0}"
+  count    = "${var.user_count}"
   user_id  = "${var.user_ids[count.index]}"
   group_id = "${var.group_create ? element(concat(oci_identity_group.this.*.id, list("")), 0) : lookup(local.group_ids[0], "id")}"
 }


### PR DESCRIPTION
Due to terraform issue:
https://github.com/hashicorp/terraform/issues/12570
value of count cannot be computed, which means if there is any compute or any terraform build-in condition in count condition, it will be ignored and continue executing.

So if condition as this:
count = "${var.group_create || length(lookup(local.group_ids[0], "id")) > 0 ? var.user_count : 0}"
even length is 0, it will continue execute user_id  = "${var.user_ids[count.index]}" then cause count.index error.
