### PR TITLE
Remove syntax that results in lists within lists

### DIFF
--- a/modules/iam-dynamic-group/main.tf
+++ b/modules/iam-dynamic-group/main.tf
@@ -34,5 +34,5 @@ resource "oci_identity_policy" "this" {
   name           = "${var.policy_name}"
   description    = "${var.policy_description}"
   compartment_id = "${var.policy_compartment_id}"
-  statements     = ["${var.policy_statements}"]
+  statements     = "${var.policy_statements}"
 }

--- a/modules/iam-group/main.tf
+++ b/modules/iam-group/main.tf
@@ -47,5 +47,5 @@ resource "oci_identity_policy" "this" {
   name           = "${var.policy_name}"
   description    = "${var.policy_description}"
   compartment_id = "${var.policy_compartment_id}"
-  statements     = ["${var.policy_statements}"]
+  statements     = "${var.policy_statements}"
 }


### PR DESCRIPTION
In v0.11, Terraform allows [] around values known to be lists, essentially resulting in a nested list that is implicitly flattened by Terraform.

In v0.12, this is no longer the case. If a value is known to be a list, it is no longer
necessary to wrap it in [].