### PR TITLE
fix(iam-compartment): remove duplicate required_providers

### DIFF
--- a/modules/iam-compartment/main.tf
+++ b/modules/iam-compartment/main.tf
@@ -1,13 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
-
-terraform {
-  required_version = ">= 0.12" // terraform version below 0.12 is not tested/supported with this module
-  required_providers {
-    oci = {
-      version = ">= 3.27" // force downloading oci-provider compatible with terraform v0.12
-    }
-  }
-}
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 
 ########################
 # Compartment


### PR DESCRIPTION
Follow up to #30, this one was missed:

```
│ Error: Duplicate required providers configuration
│
│   on .terraform/modules/iam_compartment/modules/iam-compartment/versions.tf line 2, in terraform:
│    2:   required_providers {
│
│ A module may have only one required providers configuration. The required providers were previously configured at .terraform/modules/iam_compartment/modules/iam-compartment/main.tf:5,3-21.
```

Fixes #33