### PR TITLE
fix: remove usage of list and map functions

### DIFF
--- a/modules/iam-compartment/main.tf
+++ b/modules/iam-compartment/main.tf
@@ -32,6 +32,6 @@ data "oci_identity_compartments" "this" {
 }
 
 locals {
-  compartment_ids        = concat(flatten(data.oci_identity_compartments.this.*.compartments), list(map("id", "")))
-  parent_compartment_ids = concat(flatten(data.oci_identity_compartments.this.*.compartments), list(map("compartment_id", "")))
+  compartment_ids        = concat(flatten(data.oci_identity_compartments.this.*.compartments), [{ id = "" }])
+  parent_compartment_ids = concat(flatten(data.oci_identity_compartments.this.*.compartments), [{ compartment_id = "" }])
 }

--- a/modules/iam-compartment/outputs.tf
+++ b/modules/iam-compartment/outputs.tf
@@ -3,21 +3,21 @@
 output "compartment_id" {
   description = "Compartment ocid"
   // This allows the compartment ID to be retrieved from the resource if it exists, and if not to use the data source.
-  value = var.compartment_create ? element(concat(oci_identity_compartment.this.*.id, list("")), 0) : lookup(local.compartment_ids[0], "id")
+  value = var.compartment_create ? element(concat(oci_identity_compartment.this.*.id, [""]), 0) : lookup(local.compartment_ids[0], "id")
 }
 
 output "parent_compartment_id" {
   description = "Parent Compartment ocid"
   // This allows the compartment ID to be retrieved from the resource if it exists, and if not to use the data source.
-  value = var.compartment_create ? element(concat(oci_identity_compartment.this.*.compartment_id, list("")), 0) : lookup(local.parent_compartment_ids[0], "compartment_id")
+  value = var.compartment_create ? element(concat(oci_identity_compartment.this.*.compartment_id, [""]), 0) : lookup(local.parent_compartment_ids[0], "compartment_id")
 }
 
 output "compartment_name" {
   description = "Compartment name"
-  value = var.compartment_name
+  value       = var.compartment_name
 }
 
 output "compartment_description" {
   description = "Compartment description"
-  value = var.compartment_description
+  value       = var.compartment_description
 }

--- a/modules/iam-dynamic-group/main.tf
+++ b/modules/iam-dynamic-group/main.tf
@@ -22,7 +22,7 @@ data "oci_identity_dynamic_groups" "this" {
 }
 
 locals {
-  dynamic_group_ids = concat(flatten(data.oci_identity_dynamic_groups.this.*.dynamic_groups), list(map("id", "")))
+  dynamic_group_ids = concat(flatten(data.oci_identity_dynamic_groups.this.*.dynamic_groups), [{ id = "" }])
 }
 
 ########################

--- a/modules/iam-dynamic-group/outputs.tf
+++ b/modules/iam-dynamic-group/outputs.tf
@@ -2,12 +2,12 @@
 
 output "dynamic_group_id" {
   description = "Dynamic Group ocid"
-  value = var.dynamic_group_create ? element(concat(oci_identity_dynamic_group.this.*.id, list("")), 0) : lookup(local.dynamic_group_ids[0], "id")
+  value       = var.dynamic_group_create ? element(concat(oci_identity_dynamic_group.this.*.id, [""]), 0) : lookup(local.dynamic_group_ids[0], "id")
 }
 
 output "dynamic_group_name" {
   description = "Dynamic Group name"
-  value = var.dynamic_group_name
+  value       = var.dynamic_group_name
 }
 
 output "name_ocid" {
@@ -16,5 +16,5 @@ output "name_ocid" {
 }
 output "dynamic_group_policy_name" {
   description = "Dynamic Group policy name"
-  value = var.policy_name
+  value       = var.policy_name
 }

--- a/modules/iam-group/main.tf
+++ b/modules/iam-group/main.tf
@@ -21,7 +21,7 @@ data "oci_identity_groups" "this" {
 }
 
 locals {
-  group_ids = concat(flatten(data.oci_identity_groups.this.*.groups), list(map("id", "")))
+  group_ids = concat(flatten(data.oci_identity_groups.this.*.groups), [{ "id" = "" }])
 }
 
 ########################
@@ -30,7 +30,7 @@ locals {
 resource "oci_identity_user_group_membership" "this" {
   count    = var.user_ids == null ? 0 : length(var.user_ids)
   user_id  = var.user_ids[count.index]
-  group_id = var.group_create ? element(concat(oci_identity_group.this.*.id, list("")), 0) : lookup(local.group_ids[0], "id")
+  group_id = var.group_create ? element(concat(oci_identity_group.this.*.id, [""]), 0) : lookup(local.group_ids[0], "id")
 }
 
 ########################

--- a/modules/iam-group/outputs.tf
+++ b/modules/iam-group/outputs.tf
@@ -2,12 +2,12 @@
 
 output "group_id" {
   description = "Group ocid"
-  value = var.group_create ? element(concat(oci_identity_group.this.*.id, list("")), 0) : lookup(local.group_ids[0], "id")
+  value       = var.group_create ? element(concat(oci_identity_group.this.*.id, [""]), 0) : lookup(local.group_ids[0], "id")
 }
 
 output "group_name" {
   description = "Group name"
-  value = var.group_name
+  value       = var.group_name
 }
 
 output "name_ocid" {
@@ -17,10 +17,10 @@ output "name_ocid" {
 
 output "group_description" {
   description = "Group description"
-  value = var.group_description
+  value       = var.group_description
 }
 
 output "group_policy_name" {
   description = "Group policy name"
-  value = var.policy_name
+  value       = var.policy_name
 }


### PR DESCRIPTION
These functions were deprecated in Terraform v0.12 and removed in v0.15:

https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/0-15#legacy-configuration-language-features

> Terraform can infer the necessary type conversions automatically from context. In those cases, you can just use the `[ ... ]` or `{ ... }` syntax directly, without a conversion function.

Fixes #26
Fixes #27
Closes #28