### PR TITLE
upgrade to support terraform versions > v0.12

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -39,7 +39,7 @@ provider "oci" {
  */
 
 module "iam_compartment" {
-  source                  = "oracle-terraform-modules/iam/oci//modules/iam-compartment"
+  source = "oracle-terraform-modules/iam/oci//modules/iam-compartment"
   # Pinning each module to a specific version is highly advisable. Please adjust and uncomment the line below
   # version               = "x.x.x"
   tenancy_ocid            = var.tenancy_ocid
@@ -51,7 +51,7 @@ module "iam_compartment" {
 }
 
 module "iam_subcompartment1" {
-  source                  = "oracle-terraform-modules/iam/oci//modules/iam-compartment"
+  source = "oracle-terraform-modules/iam/oci//modules/iam-compartment"
   # Pinning each module to a specific version is highly advisable. Please adjust and uncomment the line below
   # version               = "x.x.x"
   tenancy_ocid            = var.tenancy_ocid
@@ -63,7 +63,7 @@ module "iam_subcompartment1" {
 }
 
 module "iam_subcompartment2" {
-  source                  = "oracle-terraform-modules/iam/oci//modules/iam-compartment"
+  source = "oracle-terraform-modules/iam/oci//modules/iam-compartment"
   # Pinning each module to a specific version is highly advisable. Please adjust and uncomment the line below
   # version               = "x.x.x"
   tenancy_ocid            = var.tenancy_ocid
@@ -75,7 +75,7 @@ module "iam_subcompartment2" {
 }
 
 module "iam_users" {
-  source       = "oracle-terraform-modules/iam/oci//modules/iam-user"
+  source = "oracle-terraform-modules/iam/oci//modules/iam-user"
   # Pinning each module to a specific version is highly advisable. Please adjust and uncomment the line below
   # version       = "x.x.x"
   tenancy_ocid = var.tenancy_ocid
@@ -115,7 +115,7 @@ module "iam_group" {
 }
 
 module "iam_dynamic_group" {
-  source                    = "oracle-terraform-modules/iam/oci//modules/iam-dyanmic-group"
+  source = "oracle-terraform-modules/iam/oci//modules/iam-dyanmic-group"
   # Pinning each module to a specific version is highly advisable. Please adjust and uncomment the line below
   # version               = "x.x.x"
   tenancy_ocid              = var.tenancy_ocid

--- a/modules/iam-compartment/main.tf
+++ b/modules/iam-compartment/main.tf
@@ -1,14 +1,5 @@
 // Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 
-terraform {
-  required_version = ">= 0.12" // terraform version below 0.12 is not tested/supported with this module
-  required_providers {
-    oci = {
-      version = ">= 3.27" // force downloading oci-provider compatible with terraform v0.12
-    }
-  }
-}
-
 ########################
 # Compartment
 ########################
@@ -32,6 +23,6 @@ data "oci_identity_compartments" "this" {
 }
 
 locals {
-  compartment_ids        = concat(flatten(data.oci_identity_compartments.this.*.compartments), list(map("id", "")))
-  parent_compartment_ids = concat(flatten(data.oci_identity_compartments.this.*.compartments), list(map("compartment_id", "")))
+  compartment_ids        = concat(flatten(data.oci_identity_compartments.this.*.compartments), tolist([tomap({ "id" = "" })]))
+  parent_compartment_ids = concat(flatten(data.oci_identity_compartments.this.*.compartments), tolist([tomap({ "compartment_id" = "" })]))
 }

--- a/modules/iam-compartment/outputs.tf
+++ b/modules/iam-compartment/outputs.tf
@@ -3,21 +3,21 @@
 output "compartment_id" {
   description = "Compartment ocid"
   // This allows the compartment ID to be retrieved from the resource if it exists, and if not to use the data source.
-  value = var.compartment_create ? element(concat(oci_identity_compartment.this.*.id, list("")), 0) : lookup(local.compartment_ids[0], "id")
+  value = var.compartment_create ? element(concat(oci_identity_compartment.this.*.id, tolist([""])), 0) : lookup(local.compartment_ids[0], "id")
 }
 
 output "parent_compartment_id" {
   description = "Parent Compartment ocid"
   // This allows the compartment ID to be retrieved from the resource if it exists, and if not to use the data source.
-  value = var.compartment_create ? element(concat(oci_identity_compartment.this.*.compartment_id, list("")), 0) : lookup(local.parent_compartment_ids[0], "compartment_id")
+  value = var.compartment_create ? element(concat(oci_identity_compartment.this.*.compartment_id, tolist([""])), 0) : lookup(local.parent_compartment_ids[0], "compartment_id")
 }
 
 output "compartment_name" {
   description = "Compartment name"
-  value = var.compartment_name
+  value       = var.compartment_name
 }
 
 output "compartment_description" {
   description = "Compartment description"
-  value = var.compartment_description
+  value       = var.compartment_description
 }

--- a/modules/iam-compartment/variables.tf
+++ b/modules/iam-compartment/variables.tf
@@ -1,38 +1,38 @@
 // Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 
 variable "tenancy_ocid" {
-  type = string
+  type        = string
   description = "(Deprecated) The OCID of the tenancy."
-  default = null
+  default     = null
 }
 
 variable "compartment_id" {
-  type = string
+  type        = string
   description = "The OCID of the parent compartment containing the compartment. Allow for sub-compartments creation"
   default     = null
 }
 
 variable "compartment_name" {
-  type = string
+  type        = string
   description = "The name you assign to the compartment during creation. The name must be unique across all compartments in the tenancy. "
   default     = null
 }
 
 // The description is only used if compartment_create = true.
 variable "compartment_description" {
-  type = string
+  type        = string
   description = "The description you assign to the compartment. Does not have to be unique, and it's changeable. "
   default     = null
 }
 
 variable "compartment_create" {
-  type = bool
+  type        = bool
   description = "(Deprecated) Create the compartment or not. If true, the compartment will be managed by this module, and the user must have permissions to create the compartment; If false, compartment data will be returned about the compartment if it exists, if not found, then an empty string will be returned for the compartment ID."
   default     = true
 }
 
 variable "enable_delete" {
-  type = bool
+  type        = bool
   description = "Enable compartment delete on destroy. If true, compartment will be deleted when `terraform destroy` is executed; If false, compartment will not be deleted on `terraform destroy` execution"
   default     = false
 }

--- a/modules/iam-dynamic-group/main.tf
+++ b/modules/iam-dynamic-group/main.tf
@@ -22,7 +22,7 @@ data "oci_identity_dynamic_groups" "this" {
 }
 
 locals {
-  dynamic_group_ids = concat(flatten(data.oci_identity_dynamic_groups.this.*.dynamic_groups), list(map("id", "")))
+  dynamic_group_ids = concat(flatten(data.oci_identity_dynamic_groups.this.*.dynamic_groups), tolist([tomap({ "id" = "" })]))
 }
 
 ########################

--- a/modules/iam-dynamic-group/outputs.tf
+++ b/modules/iam-dynamic-group/outputs.tf
@@ -2,12 +2,12 @@
 
 output "dynamic_group_id" {
   description = "Dynamic Group ocid"
-  value = var.dynamic_group_create ? element(concat(oci_identity_dynamic_group.this.*.id, list("")), 0) : lookup(local.dynamic_group_ids[0], "id")
+  value       = var.dynamic_group_create ? element(concat(oci_identity_dynamic_group.this.*.id, tolist([""])), 0) : lookup(local.dynamic_group_ids[0], "id")
 }
 
 output "dynamic_group_name" {
   description = "Dynamic Group name"
-  value = var.dynamic_group_name
+  value       = var.dynamic_group_name
 }
 
 output "name_ocid" {
@@ -16,5 +16,5 @@ output "name_ocid" {
 }
 output "dynamic_group_policy_name" {
   description = "Dynamic Group policy name"
-  value = var.policy_name
+  value       = var.policy_name
 }

--- a/modules/iam-dynamic-group/variables.tf
+++ b/modules/iam-dynamic-group/variables.tf
@@ -1,55 +1,55 @@
 // Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 
 variable "tenancy_ocid" {
-  type = string
+  type        = string
   description = "The OCID of the tenancy."
-  default = null
+  default     = null
 }
 
 variable "dynamic_group_name" {
-  type = string
+  type        = string
   description = "The name you assign to the group during creation. The name must be unique across all compartments in the tenancy. "
-  default = null
+  default     = null
 }
 
 variable "dynamic_group_description" {
-  type = string
+  type        = string
   description = "The description you assign to the Group. Does not have to be unique, and it's changeable. "
   default     = null
 }
 
 variable "dynamic_group_create" {
-  type = bool
+  type        = bool
   description = "(Deprecated) Create the dynamic group or not. If true, the user must have permissions to create the group; If false, group data will be returned about the group if it exists, if not found, then an empty string will be returned for the group ID."
   default     = true
 }
 
 variable "matching_rule" {
-  type = string
+  type        = string
   description = "Define a matching rule or a set of matching rules to define the group members."
   default     = null
 }
 
 variable "policy_name" {
-  type = string
+  type        = string
   description = "The name you assign to the policy during creation.  "
   default     = null
 }
 
 variable "policy_description" {
-  type = string
+  type        = string
   description = "The description you assign to the policy. Does not have to be unique, and it's changeable. "
   default     = null
 }
 
 variable "policy_statements" {
-  type = list(string)
+  type        = list(string)
   description = "Define policy consists of one or more policy statements. "
   default     = null
 }
 
 variable "policy_compartment_id" {
-  type = string
+  type        = string
   description = "The compartment id assign to policy."
   default     = null
 }

--- a/modules/iam-group/main.tf
+++ b/modules/iam-group/main.tf
@@ -21,7 +21,7 @@ data "oci_identity_groups" "this" {
 }
 
 locals {
-  group_ids = concat(flatten(data.oci_identity_groups.this.*.groups), list(map("id", "")))
+  group_ids = concat(flatten(data.oci_identity_groups.this.*.groups), tolist([tomap({ "id" = "" })]))
 }
 
 ########################
@@ -30,7 +30,7 @@ locals {
 resource "oci_identity_user_group_membership" "this" {
   count    = var.user_ids == null ? 0 : length(var.user_ids)
   user_id  = var.user_ids[count.index]
-  group_id = var.group_create ? element(concat(oci_identity_group.this.*.id, list("")), 0) : lookup(local.group_ids[0], "id")
+  group_id = var.group_create ? element(concat(oci_identity_group.this.*.id, tolist([""])), 0) : lookup(local.group_ids[0], "id")
 }
 
 ########################

--- a/modules/iam-group/outputs.tf
+++ b/modules/iam-group/outputs.tf
@@ -2,12 +2,12 @@
 
 output "group_id" {
   description = "Group ocid"
-  value = var.group_create ? element(concat(oci_identity_group.this.*.id, list("")), 0) : lookup(local.group_ids[0], "id")
+  value       = var.group_create ? element(concat(oci_identity_group.this.*.id, tolist([""])), 0) : lookup(local.group_ids[0], "id")
 }
 
 output "group_name" {
   description = "Group name"
-  value = var.group_name
+  value       = var.group_name
 }
 
 output "name_ocid" {
@@ -17,10 +17,10 @@ output "name_ocid" {
 
 output "group_description" {
   description = "Group description"
-  value = var.group_description
+  value       = var.group_description
 }
 
 output "group_policy_name" {
   description = "Group policy name"
-  value = var.policy_name
+  value       = var.policy_name
 }

--- a/modules/iam-group/variables.tf
+++ b/modules/iam-group/variables.tf
@@ -1,56 +1,56 @@
 // Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 
 variable "tenancy_ocid" {
-  type = string
+  type        = string
   description = "The OCID of the tenancy."
-  default = null
+  default     = null
 }
 
 variable "group_name" {
-  type = string
+  type        = string
   description = "The name you assign to the group during creation. The name must be unique across all compartments in the tenancy."
-  default = null
+  default     = null
 }
 
 // The description is only used if group_create = true.
 variable "group_description" {
-  type = string
+  type        = string
   description = "The description you assign to the Group. Does not have to be unique, and it's changeable. "
   default     = null
 }
 
 variable "group_create" {
-  type = bool
+  type        = bool
   description = "(Deprecated) Create the group or not. If true, the user must have permissions to create the group; If false, group data will be returned about the group if it exists, if not found, then an empty string will be returned for the group ID."
   default     = true
 }
 
 variable "user_ids" {
-  type = list(string)
+  type        = list(string)
   description = "List of user ocids to be added as group member"
   default     = null
 }
 
 variable "policy_name" {
-  type = string
+  type        = string
   description = "The name you assign to the policy during creation.  "
   default     = null
 }
 
 variable "policy_description" {
-  type = string
+  type        = string
   description = "The description you assign to the policy. Does not have to be unique, and it's changeable. "
   default     = null
 }
 
 variable "policy_statements" {
-  type = list(string)
+  type        = list(string)
   description = "Define policy consists of one or more policy statements. "
   default     = null
 }
 
 variable "policy_compartment_id" {
-  type = string
+  type        = string
   description = "The compartment id where policy is created."
   default     = null
 }

--- a/modules/iam-user/variables.tf
+++ b/modules/iam-user/variables.tf
@@ -1,17 +1,17 @@
 // Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 
 variable "tenancy_ocid" {
-  type = string
+  type        = string
   description = "The OCID of the tenancy."
-  default = null
+  default     = null
 }
 
-variable users {
+variable "users" {
   description = "The name and description you assign to the user during creation. The name must be unique across all compartments in the tenancy. "
   type = list(object({
-    name = string
+    name        = string
     description = string
-    email = string
+    email       = string
   }))
   default = null
 }


### PR DESCRIPTION
- Remove duplicate "required_providers" block which is no longer supported
- Convert from "map" to "tomap" function
- Convert from "list" to "tolist" function
- Run "terraform fmt" to rewrite all Terraform configuration files to a canonical format